### PR TITLE
A bunch of fixes and GUI polish

### DIFF
--- a/common/src/main/java/dev/latvian/mods/itemfilters/gui/StringValueFilterScreen.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/gui/StringValueFilterScreen.java
@@ -5,17 +5,23 @@ import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import dev.latvian.mods.itemfilters.api.IStringValueFilter;
 import dev.latvian.mods.itemfilters.api.StringValueFilterVariant;
+import dev.latvian.mods.itemfilters.item.StringValueFilterItem;
 import dev.latvian.mods.itemfilters.net.MessageUpdateFilterItem;
+import net.minecraft.ChatFormatting;
+import net.minecraft.client.gui.components.ComponentRenderUtils;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.TextComponent;
+import net.minecraft.network.chat.TranslatableComponent;
+import net.minecraft.util.FormattedCharSequence;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
 import org.lwjgl.glfw.GLFW;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -28,7 +34,7 @@ public class StringValueFilterScreen extends Screen {
 	private final Map<String, StringValueFilterVariant> variants;
 	private final ArrayList<StringValueFilterVariant> visibleVariants;
 	private EditBox nameField;
-	private int selectedVariant = -1;
+	private int selectedVariant = 0;
 
 	public StringValueFilterScreen(IStringValueFilter f, ItemStack is, InteractionHand h) {
 		super(is.getDisplayName());
@@ -51,13 +57,16 @@ public class StringValueFilterScreen extends Screen {
 		minecraft.keyboardHandler.setSendRepeatsToGui(true);
 		int i = width / 2;
 		int j = height / 2;
-		nameField = new EditBox(font, i - 52, j - 6, 104, 12, TextComponent.EMPTY);
+		int w = (width * 3) / 4;
+		nameField = new EditBox(font, i - w / 2, j - 6, w, 12, TextComponent.EMPTY);
 		nameField.setTextColor(-1);
 		nameField.setTextColorUneditable(-1);
-		nameField.setBordered(false);
 		nameField.setResponder(this::updateVariants);
+		nameField.setMaxLength(4096);
 		nameField.setValue(filter.getValue(stack));
 		nameField.setFocus(true);
+
+		addRenderableWidget(nameField);
 	}
 
 	@Override
@@ -83,42 +92,62 @@ public class StringValueFilterScreen extends Screen {
 			}
 
 			visibleVariants.sort(null);
-			selectedVariant = -1;
+			selectedVariant = 0;
 		}
 	}
 
 	@Override
 	public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
 		if (keyCode == GLFW.GLFW_KEY_ENTER) {
-			String text = visibleVariants.size() == 1 ? visibleVariants.get(0).id : selectedVariant == -1 ? nameField.getValue() : visibleVariants.get(selectedVariant).id;
+			String text;
+			if (!variants.isEmpty() && !visibleVariants.isEmpty() && selectedVariant >= 0 && selectedVariant < visibleVariants.size()) {
+				text = visibleVariants.get(selectedVariant).id;
+			} else {
+				text = nameField.getValue();
+			}
 
 			if (variants.isEmpty() || text.isEmpty() || variants.containsKey(text)) {
-				filter.setValue(stack, text);
-				minecraft.setScreen(null);
+				ItemStack newStack = stack.copy();
+				filter.setValue(newStack, text);
+				if (newStack.hasTag()) {
+					minecraft.setScreen(null);
 
-				StringValueFilterVariant variant = variants.get(text);
-				minecraft.getToasts().addToast(new SystemToast(SystemToast.SystemToastIds.TUTORIAL_HINT, new TextComponent("Value changed!"), text.isEmpty() ? null : variant == null ? new TextComponent(text) : variant.title.copy()));
+					StringValueFilterVariant variant = variants.get(text);
+					minecraft.getToasts().addToast(new SystemToast(SystemToast.SystemToastIds.TUTORIAL_HINT, new TextComponent("Value changed!"), text.isEmpty() ? null : variant == null ? new TextComponent(text) : variant.title.copy()));
 
-				minecraft.player.setItemInHand(hand, stack);
-				new MessageUpdateFilterItem(hand, stack).send();
+					minecraft.player.setItemInHand(hand, newStack);
+					new MessageUpdateFilterItem(hand, newStack).send();
+				} else {
+					minecraft.getToasts().addToast(new SystemToast(SystemToast.SystemToastIds.TUTORIAL_HINT, new TextComponent("Invalid string!"), null));
+				}
 			} else {
 				minecraft.getToasts().addToast(new SystemToast(SystemToast.SystemToastIds.TUTORIAL_HINT, new TextComponent("Invalid string!"), null));
 			}
 
 			return true;
 		} else if (keyCode == GLFW.GLFW_KEY_TAB) {
-			selectedVariant++;
-
-			if (selectedVariant == visibleVariants.size() || 14 + selectedVariant * 10 >= height) {
-				selectedVariant = 0;
-			}
-
+			adjustSelected(!Screen.hasShiftDown());
+			return true;
+		} else if (keyCode == GLFW.GLFW_KEY_DOWN) {
+			adjustSelected(true);
+			return true;
+		} else if (keyCode == GLFW.GLFW_KEY_UP) {
+			adjustSelected(false);
 			return true;
 		} else if (nameField.keyPressed(keyCode, scanCode, modifiers)) {
 			return true;
 		}
 
 		return super.keyPressed(keyCode, scanCode, modifiers);
+	}
+
+	private void adjustSelected(boolean forward) {
+		selectedVariant += forward ? 1 : -1;
+		if (selectedVariant < 0) {
+			selectedVariant = visibleVariants.size() - 1;
+		} else if (selectedVariant >= visibleVariants.size()) {
+			selectedVariant = 0;
+		}
 	}
 
 	@Override
@@ -138,12 +167,17 @@ public class StringValueFilterScreen extends Screen {
 
 		if (mouseButton == 1) {
 			nameField.setValue("");
-			return true;
 		} else {
 			nameField.mouseClicked(mouseX, mouseY, mouseButton);
 			nameField.setFocus(true);
-			return true;
 		}
+		return true;
+	}
+
+	@Override
+	public boolean mouseScrolled(double d, double e, double delta) {
+		adjustSelected(delta < 0);
+		return true;
 	}
 
 	@Override
@@ -153,16 +187,26 @@ public class StringValueFilterScreen extends Screen {
 		RenderSystem.disableBlend();
 
 		if (!variants.isEmpty()) {
-			drawString(matrixStack, font, "Variants [" + visibleVariants.size() + "] [Press Tab]", 4, 4, -1);
+			int drawY = 4 + font.lineHeight;
+			int nLines = (height - drawY) / font.lineHeight;
 
-			for (int i = 0; i < visibleVariants.size(); i++) {
+			drawString(matrixStack, font, new TranslatableComponent("itemfilters.variants", visibleVariants.size()).withStyle(ChatFormatting.AQUA), 4, 4, -1);
+
+			List<FormattedCharSequence> lines = ComponentRenderUtils.wrapComponents(new TranslatableComponent("itemfilters.help_text.variants").withStyle(ChatFormatting.DARK_AQUA), width / 2, font);
+			for (int i = 0; i < lines.size(); i++) {
+				FormattedCharSequence line = lines.get(i);
+				drawString(matrixStack, font, line, width - font.width(line) - 4, 4 + i * font.lineHeight, -1);
+			}
+
+			int first = visibleVariants.size() < nLines ? 0 : Math.max(0, selectedVariant - (nLines / 2));
+			for (int i = first; i < visibleVariants.size() && drawY < (height - font.lineHeight); i++) {
 				StringValueFilterVariant variant = visibleVariants.get(i);
-				drawString(matrixStack, font, variant.title.getString(), variant.icon.isEmpty() ? 4 : 14, 14 + i * 10, i == selectedVariant ? 0xFFFFFF00 : -1);
+				drawString(matrixStack, font, variant.title.getString(), variant.icon.isEmpty() ? 4 : 14, drawY, i == selectedVariant ? 0xFFFFFF00 : -1);
 
 				if (!variant.icon.isEmpty()) {
 					PoseStack modelViewStack = RenderSystem.getModelViewStack();
 					modelViewStack.pushPose();
-					modelViewStack.translate(4, 14 + i * 10, 0);
+					modelViewStack.translate(4, drawY, 0);
 					modelViewStack.scale(0.5F, 0.5F, 1F);
 					RenderSystem.applyModelViewMatrix();
 					itemRenderer.blitOffset = 100F;
@@ -174,13 +218,27 @@ public class StringValueFilterScreen extends Screen {
 					modelViewStack.popPose();
 					RenderSystem.applyModelViewMatrix();
 				}
+				drawY += font.lineHeight;
+			}
+			nameField.x = width / 2;
+			nameField.setWidth(width / 3);
 
-				if (14 + i * 10 >= height) {
-					break;
+			drawString(matrixStack, font, new TranslatableComponent("itemfilters.help_text.filter"), nameField.x, nameField.y - font.lineHeight - 2, 0xFFFFFFFF);
+		} else {
+			int w = (width * 3) / 4;
+			nameField.x = (width - w) / 2;
+			nameField.setWidth(w);
+
+			if (stack.getItem() instanceof StringValueFilterItem filterItem) {
+				List<FormattedCharSequence> lines = ComponentRenderUtils.wrapComponents(new TranslatableComponent(filterItem.getHelpKey()), nameField.getWidth(), font);
+				int textY = nameField.y - 3 - font.lineHeight * lines.size();
+				int color = 0xFFFFFFFF;
+				for (var line : lines) {
+					drawString(matrixStack, font, line, nameField.x, textY, color);
+					color = 0xFF999999;
+					textY += font.lineHeight;
 				}
 			}
 		}
-
-		nameField.render(matrixStack, mouseX, mouseY, partialTicks);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/gui/StringValueFilterScreen.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/gui/StringValueFilterScreen.java
@@ -109,7 +109,7 @@ public class StringValueFilterScreen extends Screen {
 			if (variants.isEmpty() || text.isEmpty() || variants.containsKey(text)) {
 				ItemStack newStack = stack.copy();
 				filter.setValue(newStack, text);
-				if (newStack.hasTag()) {
+				if (newStack.hasTag() || text.isEmpty()) {
 					minecraft.setScreen(null);
 
 					StringValueFilterVariant variant = variants.get(text);

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/CustomFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/CustomFilterItem.java
@@ -45,7 +45,7 @@ public class CustomFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new CustomFilterData(stack);
 	}
 

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/DamageFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/DamageFilterItem.java
@@ -80,7 +80,7 @@ public class DamageFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new DamageData(stack);
 	}
 
@@ -110,5 +110,10 @@ public class DamageFilterItem extends StringValueFilterItem {
 
 	@Override
 	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
+	}
+
+	@Override
+	public String getHelpKey() {
+		return "itemfilters.help_text.damage";
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/ItemGroupFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/ItemGroupFilterItem.java
@@ -54,7 +54,7 @@ public class ItemGroupFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new ItemGroupData(stack);
 	}
 
@@ -109,7 +109,7 @@ public class ItemGroupFilterItem extends StringValueFilterItem {
 			for (Item item : Registry.ITEM) {
 				try {
 					item.fillItemCategory(data.getValue(), allItems);
-				} catch (Throwable ex) {
+				} catch (Throwable ignored) {
 				}
 			}
 

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/MaxCountFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/MaxCountFilterItem.java
@@ -66,7 +66,7 @@ public class MaxCountFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new MaxCountData(stack);
 	}
 
@@ -88,5 +88,10 @@ public class MaxCountFilterItem extends StringValueFilterItem {
 			case 4 -> d1 < d2;
 			default -> d1 == d2;
 		};
+	}
+
+	@Override
+	public String getHelpKey() {
+		return "itemfilters.help_text.max_count";
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/ModFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/ModFilterItem.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 public class ModFilterItem extends StringValueFilterItem {
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new SimpleStringData(stack);
 	}
 
@@ -36,10 +36,9 @@ public class ModFilterItem extends StringValueFilterItem {
 			if (mods.add(id)) {
 				var variant = new StringValueFilterVariant(id);
 				variant.title = new TextComponent(Platform.getOptionalMod(id).map(Mod::getName).orElse(id));
-				variant.icon = new ItemStack(itemEntry.getValue());
-				if(id.equals("minecraft")) {
-					variant.icon = Items.GRASS_BLOCK.getDefaultInstance();;
-				}
+				variant.icon = id.equals("minecraft") ?
+						Items.GRASS_BLOCK.getDefaultInstance() :
+						new ItemStack(itemEntry.getValue());
 				variants.add(variant);
 			}
 		}

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/RegExFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/RegExFilterItem.java
@@ -28,7 +28,7 @@ public class RegExFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new RegExData(stack);
 	}
 
@@ -45,5 +45,10 @@ public class RegExFilterItem extends StringValueFilterItem {
 		}
 
 		return false;
+	}
+
+	@Override
+	public String getHelpKey() {
+		return "itemfilters.help_text.regex";
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/StringValueFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/StringValueFilterItem.java
@@ -60,4 +60,8 @@ public abstract class StringValueFilterItem extends BaseFilterItem implements IS
 			info.add(s);
 		}
 	}
+
+	public String getHelpKey() {
+		return "itemfilters.help_text.filter";
+	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/StrongNBTFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/StrongNBTFilterItem.java
@@ -87,7 +87,7 @@ public class StrongNBTFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new NBTData(stack);
 	}
 
@@ -112,5 +112,10 @@ public class StrongNBTFilterItem extends StringValueFilterItem {
 		CompoundTag tag1 = data.getValue();
 		CompoundTag tag2 = stack.getTag();
 		return Objects.equals(tag1, tag2);
+	}
+
+	@Override
+	public String getHelpKey() {
+		return "itemfilters.help_text.nbt";
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/StrongNBTFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/StrongNBTFilterItem.java
@@ -1,5 +1,6 @@
 package dev.latvian.mods.itemfilters.item;
 
+import net.minecraft.core.Registry;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.TagParser;
@@ -9,11 +10,13 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * @author LatvianModder
@@ -118,4 +121,10 @@ public class StrongNBTFilterItem extends StringValueFilterItem {
 	public String getHelpKey() {
 		return "itemfilters.help_text.nbt";
 	}
+
+    @Override
+    public void getItems(ItemStack filter, Set<Item> set) {
+		// any item could potentially have NBT, so we need the lot
+		Registry.ITEM.forEach(set::add);
+    }
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/TagFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/TagFilterItem.java
@@ -49,7 +49,7 @@ public class TagFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public StringValueData createData(ItemStack stack) {
+	public StringValueData<?> createData(ItemStack stack) {
 		return new TagData(stack);
 	}
 

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/WeakNBTFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/WeakNBTFilterItem.java
@@ -33,4 +33,9 @@ public class WeakNBTFilterItem extends StrongNBTFilterItem {
 
 		return true;
 	}
+
+	@Override
+	public String getHelpKey() {
+		return "itemfilters.help_text.weak_nbt";
+	}
 }

--- a/common/src/main/resources/assets/itemfilters/lang/en_us.json
+++ b/common/src/main/resources/assets/itemfilters/lang/en_us.json
@@ -33,5 +33,13 @@
 	"item.itemfilters.weak_nbt": "NBT Filter (Weak)",
 	"item.itemfilters.weak_nbt.description": "Matches if only specified part of NBT is present",
 	"item.itemfilters.custom": "Custom Filter",
-	"item.itemfilters.custom.description": "Requires a mod or a script, usually KubeJS, to make it work"
+	"item.itemfilters.custom.description": "Requires a mod or a script, usually KubeJS, to make it work",
+	"itemfilters.variants": "Variants [%d]",
+	"itemfilters.help_text.variants": "Tab, Scroll Wheel, Cursor Up/Down: adjust highlight\nEnter: select highlighted",
+	"itemfilters.help_text.filter": "Filter (Right-Click to clear)",
+	"itemfilters.help_text.nbt": "NBT String\n▶ e.g. { text:\"hello\", value: 1, active: true }",
+	"itemfilters.help_text.weak_nbt": "Weak NBT String\n▶ e.g. { text:\"hello\", value: 1, active: true }\n▶ Only the NBT fields supplied will be checked (any other fields in the item are ignored)",
+	"itemfilters.help_text.regex": "Regular Expression\n Matched against the item ID\n▶ e.g. \"^minecraft:\" matches all vanilla items",
+	"itemfilters.help_text.max_count": "Maximum Stack Size\n▶ May also include relational operators, e.g. \"<64\" or \">=16\"",
+	"itemfilters.help_text.damage": "Item Damage\n▶ May also include relational operators, e.g. \"<10\" or \">=5\"\n and optionally by percentage, e.g. \">50%\""
 }


### PR DESCRIPTION
* Fixed `getDisplayItemStacks()` for Strong & Weak NBT Filters
* Textfield for string value filters is wider and can have up to 4096 characters now (up from 32 chars which was useless for NBT filters)
* Gave the textfield a border, since a floating cursor is a bit unintuitive
* Variant filter GUI is much more usable now - can use mousewheel or cursor keys to scroll it, and can scroll the entire list if larger than the screen height (e.g. all known item tags)
* Added help text to various parts of all GUI's making it clear what sort of input is expected
* Invalid input (e.g. NBT with a syntax error) no longer wipes the current item's data
* Localized some text in the GUI