### PR TITLE
add caching of matching-stack display for filter items

### DIFF
--- a/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
@@ -51,6 +51,10 @@ public class DisplayStacksCache {
         return allKnownStacks.stream().filter(candidate -> f.filter(filterStack, candidate)).toList();
     }
 
+    public static void clear() {
+        cache.clear();
+    }
+
     private static class CacheKey {
         private final int key;
 

--- a/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
@@ -1,0 +1,74 @@
+package dev.latvian.mods.itemfilters;
+
+import dev.latvian.mods.itemfilters.api.IItemFilter;
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import net.minecraft.core.NonNullList;
+import net.minecraft.core.Registry;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+/**
+ * LRU cache to improve the performance of {@link dev.latvian.mods.itemfilters.api.IItemFilter#getDisplayItemStacks(ItemStack, List)}
+ * (and thus {@link dev.latvian.mods.itemfilters.api.ItemFiltersAPI#getDisplayItemStacks(ItemStack, List)}
+ */
+public class DisplayStacksCache {
+    private static final int MAX_CACHE_SIZE = 1024;
+    private static final Object2ObjectLinkedOpenHashMap<CacheKey, List<ItemStack>> cache = new Object2ObjectLinkedOpenHashMap<>(MAX_CACHE_SIZE);
+    private static final NonNullList<ItemStack> allKnownStacks = NonNullList.create();
+
+    @Nonnull
+    public static List<ItemStack> getCachedDisplayStacks(ItemStack filterStack) {
+        CacheKey key = new CacheKey(filterStack);
+
+        List<ItemStack> result = cache.getAndMoveToFirst(key);
+        if (result == null) {
+            result = computeMatchingStacks(filterStack);
+            cache.put(key, result);
+            if (cache.size() >= MAX_CACHE_SIZE) {
+                cache.removeLast();
+            }
+        }
+
+        return result;
+    }
+
+    private static List<ItemStack> computeMatchingStacks(ItemStack filterStack) {
+        if (allKnownStacks.isEmpty()) {
+            for (Item item : Registry.ITEM) {
+                try {
+                    // all items appear in the creative search tab
+                    item.fillItemCategory(CreativeModeTab.TAB_SEARCH, allKnownStacks);
+                } catch (Throwable ignored) {
+                }
+            }
+        }
+
+        IItemFilter f = (IItemFilter) filterStack.getItem();
+        return allKnownStacks.stream().filter(candidate -> f.filter(filterStack, candidate)).toList();
+    }
+
+    private static class CacheKey {
+        private final int key;
+
+        private CacheKey(ItemStack filterStack) {
+            key = Objects.hash(Registry.ITEM.getId(filterStack.getItem()), filterStack.hasTag() ? filterStack.getTag().hashCode() : 0);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CacheKey cacheKey = (CacheKey) o;
+            return key == cacheKey.key;
+        }
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(key);
+        }
+    }
+}

--- a/common/src/main/java/dev/latvian/mods/itemfilters/ItemFilters.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/ItemFilters.java
@@ -1,16 +1,24 @@
 package dev.latvian.mods.itemfilters;
 
 import dev.architectury.registry.CreativeTabRegistry;
+import dev.architectury.registry.ReloadListenerRegistry;
 import dev.architectury.registry.menu.MenuRegistry;
 import dev.architectury.registry.registries.Registries;
 import dev.architectury.utils.EnvExecutor;
+import dev.architectury.utils.GameInstance;
 import dev.latvian.mods.itemfilters.api.ItemFiltersItems;
 import dev.latvian.mods.itemfilters.client.ItemFiltersClient;
 import dev.latvian.mods.itemfilters.gui.InventoryFilterMenu;
 import dev.latvian.mods.itemfilters.net.ItemFiltersNet;
+import dev.latvian.mods.itemfilters.net.MessageClearDisplayCache;
 import net.fabricmc.api.EnvType;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.packs.PackType;
+import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
 
@@ -30,5 +38,28 @@ public class ItemFilters {
 
 		ItemFiltersNet.init();
 		EnvExecutor.runInEnv(EnvType.CLIENT, () -> proxy::setup);
+
+		ReloadListenerRegistry.register(PackType.SERVER_DATA, new TagReloadListener());
+	}
+
+	private static class TagReloadListener implements ResourceManagerReloadListener {
+		@Override
+		public void onResourceManagerReload(ResourceManager resourceManager) {
+			// need to clear all cached items since we can't know for sure if a tag filter has been used
+			// (it could be arbitrarily deeply nested inside other filters)
+			DisplayStacksCache.clear();
+
+			// notify all non-local players that the cache needs to be cleared (local player doesn't need notifying
+			// since the displayed items cache is static and shared between integrated server and client)
+			MinecraftServer server = GameInstance.getServer();
+			if (server != null) {
+				MessageClearDisplayCache msg = new MessageClearDisplayCache();
+				for (ServerPlayer player : server.getPlayerList().getPlayers()) {
+					if (!server.isSingleplayerOwner(player.getGameProfile())) {
+						ItemFiltersNet.MAIN.sendToPlayer(player, msg);
+					}
+				}
+			}
+		}
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/api/ItemFiltersAPI.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/api/ItemFiltersAPI.java
@@ -62,6 +62,7 @@ public class ItemFiltersAPI {
 	/**
 	 * @param filter filter item. If it's not an IItemFilter, then it will be compared using areItemStacksEqual() method.
 	 * @param stack  item that is being checked.
+	 * @return true if the item matches the filter
 	 */
 	public static boolean filter(ItemStack filter, ItemStack stack) {
 		if (filter.isEmpty()) {
@@ -72,6 +73,14 @@ public class ItemFiltersAPI {
 		return f == null ? areItemStacksEqual(filter, stack) : f.filter(filter, stack);
 	}
 
+	/**
+	 * Add all the known item stacks that match the given filter to the given list. Do not modify these item stacks
+	 * without first copying them; they come from a shared cached pool.
+	 * @param filter the filter item
+	 * @param list list of item stacks to add to
+	 * @implNote this list is computed from the list of all item stacks known from the creative search tab and is
+	 * cached internally per filter item for performance reasons
+	 */
 	public static void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
 		if (filter.isEmpty()) {
 			return;
@@ -86,6 +95,15 @@ public class ItemFiltersAPI {
 		}
 	}
 
+	/**
+	 * Get a list of all items that this filter might apply to
+	 * @param filter the filter item
+	 * @param list set of items to add to
+	 * @deprecated this method was here primarily to support {@link #getDisplayItemStacks(ItemStack, List)}, which
+	 * should always be used in preference. It is no longer used for that purpose either, since it did not reliably
+	 * work for every filter type. tl;dr there's no good reason to use this anymore
+	 */
+	@Deprecated
 	public static void getItems(ItemStack filter, Set<Item> list) {
 		if (filter.isEmpty()) {
 			return;

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/BlockFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/BlockFilterItem.java
@@ -23,21 +23,6 @@ public class BlockFilterItem extends BaseFilterItem {
 	}
 
 	@Override
-	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
-		NonNullList<ItemStack> allItems = NonNullList.create();
-
-		for (Block block : Registry.BLOCK) {
-			Item item = block.asItem();
-
-			if (item != Items.AIR && item instanceof BlockItem) {
-				item.fillItemCategory(CreativeModeTab.TAB_SEARCH, allItems);
-			}
-		}
-
-		list.addAll(allItems);
-	}
-
-	@Override
 	public void getItems(ItemStack filter, Set<Item> set) {
 		for (Block block : Registry.BLOCK) {
 			Item item = block.asItem();

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/DamageFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/DamageFilterItem.java
@@ -109,10 +109,6 @@ public class DamageFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
-	}
-
-	@Override
 	public String getHelpKey() {
 		return "itemfilters.help_text.damage";
 	}

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/ItemGroupFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/ItemGroupFilterItem.java
@@ -100,24 +100,6 @@ public class ItemGroupFilterItem extends StringValueFilterItem {
 	}
 
 	@Override
-	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
-		ItemGroupData data = getStringValueData(filter);
-
-		if (data.getValue() != null) {
-			NonNullList<ItemStack> allItems = NonNullList.create();
-
-			for (Item item : Registry.ITEM) {
-				try {
-					item.fillItemCategory(data.getValue(), allItems);
-				} catch (Throwable ignored) {
-				}
-			}
-
-			list.addAll(allItems);
-		}
-	}
-
-	@Override
 	@Environment(EnvType.CLIENT)
 	public void addInfo(ItemStack filter, FilterInfo info, boolean expanded) {
 		ItemGroupData data = getStringValueData(filter);

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/ORFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/ORFilterItem.java
@@ -22,17 +22,4 @@ public class ORFilterItem extends InventoryFilterItem {
 		return false;
 	}
 
-	@Override
-	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
-		ItemInventory inventory = getInventory(filter);
-
-		for (ItemStack item : inventory.getItems()) {
-			if (ItemFiltersAPI.isFilter(item)) {
-				super.getDisplayItemStacks(filter, list);
-				return;
-			}
-		}
-
-		list.addAll(inventory.getItems());
-	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/TagFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/TagFilterItem.java
@@ -4,19 +4,14 @@ import dev.latvian.mods.itemfilters.api.StringValueFilterVariant;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.Holder;
-import net.minecraft.core.NonNullList;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.ItemTags;
-import net.minecraft.tags.Tag;
 import net.minecraft.tags.TagKey;
-import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -79,16 +74,6 @@ public class TagFilterItem extends StringValueFilterItem {
 			variant.icon = e.getSecond().stream().findAny().map(ItemStack::new).orElse(ItemStack.EMPTY);
 			return variant;
 		}).toList();
-	}
-
-	@Override
-	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
-		NonNullList<ItemStack> list1 = NonNullList.create();
-
-		StreamSupport.stream(Registry.ITEM.getTagOrEmpty(TagKey.create(Registry.ITEM_REGISTRY, new ResourceLocation(getValue(filter)))).spliterator(), false)
-				.forEach(e -> e.value().fillItemCategory(CreativeModeTab.TAB_SEARCH, list1));
-
-		list.addAll(list1);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/itemfilters/net/ItemFiltersNet.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/net/ItemFiltersNet.java
@@ -12,5 +12,6 @@ public class ItemFiltersNet {
 
 	public static void init() {
 		MAIN.register(MessageUpdateFilterItem.class, MessageUpdateFilterItem::write, MessageUpdateFilterItem::new, MessageUpdateFilterItem::handle);
+		MAIN.register(MessageClearDisplayCache.class, MessageClearDisplayCache::write, MessageClearDisplayCache::new, MessageClearDisplayCache::handle);
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/net/MessageClearDisplayCache.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/net/MessageClearDisplayCache.java
@@ -1,0 +1,29 @@
+package dev.latvian.mods.itemfilters.net;
+
+import dev.architectury.networking.NetworkManager;
+import dev.architectury.utils.Env;
+import dev.latvian.mods.itemfilters.DisplayStacksCache;
+import net.minecraft.network.FriendlyByteBuf;
+
+import java.util.function.Supplier;
+
+/**
+ * Sent to non-local clients by the server when tags are reloaded
+ * TODO: remove this when architectury supports a tags-synced event
+ */
+public class MessageClearDisplayCache {
+    public MessageClearDisplayCache() {
+    }
+
+    public MessageClearDisplayCache(@SuppressWarnings("unused") FriendlyByteBuf buf) {
+    }
+
+    public void write(@SuppressWarnings("unused") FriendlyByteBuf buf) {
+    }
+
+    public void handle(Supplier<NetworkManager.PacketContext> context) {
+        if (context.get().getEnvironment() == Env.CLIENT) {
+            context.get().queue(DisplayStacksCache::clear);
+        }
+    }
+}


### PR DESCRIPTION
As discussed yesterday, this should help the performance of `getDisplayItemStacks()` a lot

* An LRU cache (1024 elements max) is used to cache the result on a per-filter basis.
* Cache key is derived from the filter item's numeric item ID, and the numeric hash code of its NBT tag, if any.
* Display stacks are pulled from a single pool of all known item stacks, which is effectively what appears in the creative search tab. 
* Also deprecated `IItemFilter#getItems`, since it's no longer required by `IItemFilter#getDisplayItemStacks`, and doesn't work reliably for all filter types anyway.
* The change also has the desirable side-effect of making `getDisplayItemStacks()` work for *all* filter types (previously this returned an empty list for many filter types)

You'll also notice I deleted all the overrides for `getDisplayItemStacks()` (except for `AlwaysFalseFilterItem`) - as I understand it, the original purpose was to use a more performant implementation if possible for the filter in question. But now we cache everything, that isn't necessary anymore. Just apply the filter's `filter()` method to all known item stacks, cache the result for that filter, and done; should only be slow the first time it's called.