### PR TITLE
fix: ensure all items in an OR filter get seen by getDisplayItemStacks()

### DIFF
--- a/common/src/main/java/dev/latvian/mods/itemfilters/item/ORFilterItem.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/item/ORFilterItem.java
@@ -22,4 +22,17 @@ public class ORFilterItem extends InventoryFilterItem {
 		return false;
 	}
 
+	@Override
+	public void getDisplayItemStacks(ItemStack filter, List<ItemStack> list) {
+		ItemInventory inventory = getInventory(filter);
+
+		for (ItemStack stack1 : inventory.getItems()) {
+			if (ItemFiltersAPI.isFilter(stack1)) {
+				super.getDisplayItemStacks(filter, list);
+			} else {
+				// allows for the possibility of custom items in the filter which aren't in the creative search tab
+				list.add(stack1);
+			}
+		}
+	}
 }


### PR DESCRIPTION
Items in the filter which aren't in the creative search tab currently get missed
This generally applies to items with custom NBT data