### PR TITLE
fix: populate the creative search tab when necessary

### DIFF
--- a/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
@@ -38,9 +38,7 @@ public class DisplayStacksCache {
     private static List<ItemStack> computeMatchingStacks(ItemStack filterStack) {
         IItemFilter f = (IItemFilter) filterStack.getItem();
 
-        if (!CreativeModeTabs.searchTab().hasAnyItems()) {
-            ItemFilters.proxy.registryAccess().ifPresent(ra -> CreativeModeTabs.tryRebuildTabContents(FeatureFlags.DEFAULT_FLAGS, true, ra));
-        }
+        ItemFilters.proxy.registryAccess().ifPresent(ra -> CreativeModeTabs.tryRebuildTabContents(FeatureFlags.DEFAULT_FLAGS, true, ra));
 
         return CreativeModeTabs.searchTab().getSearchTabDisplayItems().stream()
                 .filter(candidate -> f.filter(filterStack, candidate))

--- a/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/DisplayStacksCache.java
@@ -2,8 +2,8 @@ package dev.latvian.mods.itemfilters;
 
 import dev.latvian.mods.itemfilters.api.IItemFilter;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-import net.minecraft.core.NonNullList;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.world.flag.FeatureFlags;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -37,6 +37,11 @@ public class DisplayStacksCache {
 
     private static List<ItemStack> computeMatchingStacks(ItemStack filterStack) {
         IItemFilter f = (IItemFilter) filterStack.getItem();
+
+        if (!CreativeModeTabs.searchTab().hasAnyItems()) {
+            ItemFilters.proxy.registryAccess().ifPresent(ra -> CreativeModeTabs.tryRebuildTabContents(FeatureFlags.DEFAULT_FLAGS, true, ra));
+        }
+
         return CreativeModeTabs.searchTab().getSearchTabDisplayItems().stream()
                 .filter(candidate -> f.filter(filterStack, candidate))
                 .toList();

--- a/common/src/main/java/dev/latvian/mods/itemfilters/ItemFiltersCommon.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/ItemFiltersCommon.java
@@ -1,8 +1,14 @@
 package dev.latvian.mods.itemfilters;
 
+import dev.architectury.utils.GameInstance;
 import dev.latvian.mods.itemfilters.api.IStringValueFilter;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+
+import java.util.Optional;
 
 /**
  * @author LatvianModder
@@ -12,5 +18,15 @@ public class ItemFiltersCommon {
 	}
 
 	public void openStringValueFilterScreen(IStringValueFilter filter, ItemStack stack, InteractionHand hand) {
+	}
+
+	public Optional<RegistryAccess> registryAccess() {
+		if (GameInstance.getServer() != null) {
+			ServerLevel overworld = GameInstance.getServer().getLevel(Level.OVERWORLD);
+			if (overworld != null) {
+				return Optional.of(overworld.registryAccess());
+			}
+		}
+		return Optional.empty();
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/itemfilters/client/ItemFiltersClient.java
+++ b/common/src/main/java/dev/latvian/mods/itemfilters/client/ItemFiltersClient.java
@@ -8,9 +8,12 @@ import dev.latvian.mods.itemfilters.gui.InventoryFilterMenu;
 import dev.latvian.mods.itemfilters.gui.InventoryFilterScreen;
 import dev.latvian.mods.itemfilters.gui.StringValueFilterScreen;
 import net.minecraft.client.Minecraft;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.ItemStack;
+
+import java.util.Optional;
 
 /**
  * @author LatvianModder
@@ -26,5 +29,10 @@ public class ItemFiltersClient extends ItemFiltersCommon {
 	@Override
 	public void openStringValueFilterScreen(IStringValueFilter filter, ItemStack stack, InteractionHand hand) {
 		Minecraft.getInstance().setScreen(new StringValueFilterScreen(filter, stack, hand));
+	}
+
+	@Override
+	public Optional<RegistryAccess> registryAccess() {
+		return Minecraft.getInstance().level == null ? Optional.empty() : Optional.of(Minecraft.getInstance().level.registryAccess());
 	}
 }


### PR DESCRIPTION
When searching for matching stacks, search tab is not necessarily filled yet.